### PR TITLE
LocalStorageのインスタンスを取得する処理を一か所にまとめた

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,12 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:device_preview/device_preview.dart';
 import 'package:flutter/foundation.dart';
 import 'package:saving_girlfriend/route/go_router.dart';
+import 'services/local_storage_service.dart';
 
-void main() {
-  runApp(  DevicePreview(
-    enabled: !kReleaseMode,
-    builder: (context) => MyApp(), // Wrap your app
-  ),);
+void main() async {
+  await LocalStorageService.init();
+  runApp(
+    DevicePreview(
+      enabled: !kReleaseMode,
+      builder: (context) => MyApp(), // Wrap your app
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {

--- a/lib/services/local_storage_service.dart
+++ b/lib/services/local_storage_service.dart
@@ -2,29 +2,33 @@ import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class LocalStorageService {
+  // インスタンスは最初に取得する
+  static late SharedPreferences prefs;
   // 各データのキーを定数として定義しておくとタイプミスを防げます
   static const String _currentCharacterKey = 'current_character';
   static const String _likeabilityKeyPrefix = '_likeability'; // キャラごとに好感度を保存
   static const String _tributeHistoryKey = 'tribute_history';
   static const String _targetSavingAmountKey = 'target_saving_amount';
-  static const String _defaultContributionAmountKey = 'default_contribution_amount';
+  static const String _defaultContributionAmountKey =
+      'default_contribution_amount';
   static const String _notificationsEnabledKey = 'notifications_enabled';
   static const String _bgmVolumeKey = 'bgm_volume';
 
   // --- 保存 (Save) ---
 
+  static Future<void> init() async {
+    prefs = await SharedPreferences.getInstance();
+  }
+
   Future<void> saveCurrentCharacter(String characterId) async {
-    final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_currentCharacterKey, characterId);
   }
 
   Future<void> saveLikeability(String characterId, int value) async {
-    final prefs = await SharedPreferences.getInstance();
     await prefs.setInt('$characterId$_likeabilityKeyPrefix', value);
   }
 
   Future<void> saveTributeHistory(List<Map<String, dynamic>> history) async {
-    final prefs = await SharedPreferences.getInstance();
     String jsonString = jsonEncode(history);
     await prefs.setString(_tributeHistoryKey, jsonString);
   }
@@ -35,56 +39,50 @@ class LocalStorageService {
     required bool notificationsEnabled,
     required double bgmVolume,
   }) async {
-    final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_targetSavingAmountKey, targetSavingAmount);
-    await prefs.setInt(_defaultContributionAmountKey, defaultContributionAmount);
+    await prefs.setInt(
+        _defaultContributionAmountKey, defaultContributionAmount);
     await prefs.setBool(_notificationsEnabledKey, notificationsEnabled);
     await prefs.setDouble(_bgmVolumeKey, bgmVolume);
   }
 
-
   // --- 読み込み (Load) ---
 
   Future<String?> getCurrentCharacter() async {
-    final prefs = await SharedPreferences.getInstance();
     return prefs.getString(_currentCharacterKey);
   }
 
   Future<int> getLikeability(String characterId) async {
-    final prefs = await SharedPreferences.getInstance();
     // 保存されていない場合の初期値は 50 などに設定
     return prefs.getInt('$characterId$_likeabilityKeyPrefix') ?? 50;
   }
 
   Future<List<Map<String, dynamic>>> getTributeHistory() async {
-    final prefs = await SharedPreferences.getInstance();
     final jsonString = prefs.getString(_tributeHistoryKey);
     if (jsonString != null && jsonString.isNotEmpty) {
       // JSON文字列をデコードして List<Map> に変換
       final List<dynamic> decodedList = jsonDecode(jsonString);
-      return decodedList.map((item) => Map<String, dynamic>.from(item)).toList();
+      return decodedList
+          .map((item) => Map<String, dynamic>.from(item))
+          .toList();
     }
     // データがない場合は空のリストを返す
     return [];
   }
 
   Future<int?> getTargetSavingAmount() async {
-    final prefs = await SharedPreferences.getInstance();
     return prefs.getInt(_targetSavingAmountKey);
   }
 
   Future<int?> getDefaultContributionAmount() async {
-    final prefs = await SharedPreferences.getInstance();
     return prefs.getInt(_defaultContributionAmountKey);
   }
 
   Future<bool> getNotificationsEnabled() async {
-    final prefs = await SharedPreferences.getInstance();
     return prefs.getBool(_notificationsEnabledKey) ?? true; // Default to true
   }
 
   Future<double> getBgmVolume() async {
-    final prefs = await SharedPreferences.getInstance();
     return prefs.getDouble(_bgmVolumeKey) ?? 0.75; // Default to 0.75
   }
 }


### PR DESCRIPTION
main関数を呼び出した時にLocalStorageのインスタンスを取得するように変更しました。以下、変更点です。
lib\main.dart
```
void main() async { //main関数をasync関数に変更
  await LocalStorageService.init(); // 最初にLocalStorageのインスタンスを取得
  runApp(
    DevicePreview(
      enabled: !kReleaseMode,
      builder: (context) => MyApp(), // Wrap your app
    ),
  );
}
```
lib\services\local_storage_service.dartに以下を追加しました
```
  static late SharedPreferences prefs;

  static Future<void> init() async {
    prefs = await SharedPreferences.getInstance();
  }
```