### PR TITLE
riverpodを実装した

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,14 +3,14 @@ import 'package:device_preview/device_preview.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:saving_girlfriend/route/go_router.dart';
-import 'services/local_storage_service.dart';
 
 void main() async {
-  await LocalStorageService.init();
   runApp(
     DevicePreview(
       enabled: !kReleaseMode,
-      builder: (context) => ProviderScope(child: MyApp()),
+      builder: (context) => ProviderScope(
+        child: MyApp(),
+      ),
     ),
   );
 }

--- a/lib/models/episode.dart
+++ b/lib/models/episode.dart
@@ -1,0 +1,15 @@
+class Episode {
+  final int number;
+  final String title;
+  final int requiredLikeability; // エピソードをアンロックするために必要な好感度
+  bool isLocked;
+  final bool showUnlockedIcon; // クリア済みの印
+
+  Episode({
+    required this.number,
+    required this.title,
+    this.requiredLikeability = 0, // デフォルトは0
+    this.isLocked = false,
+    this.showUnlockedIcon = true,
+  });
+}

--- a/lib/models/settings_state.dart
+++ b/lib/models/settings_state.dart
@@ -1,0 +1,27 @@
+class SettingsState {
+  final int targetSavingAmount;
+  final int defaultContributionAmount;
+  final bool notificationsEnabled;
+  final double bgmVolume;
+
+  SettingsState(
+      {required this.targetSavingAmount,
+      required this.defaultContributionAmount,
+      required this.notificationsEnabled,
+      required this.bgmVolume});
+
+  SettingsState copyWith({
+    int? targetSavingAmount,
+    int? defaultContributionAmount,
+    bool? notificationsEnabled,
+    double? bgmVolume,
+  }) {
+    return SettingsState(
+      targetSavingAmount: targetSavingAmount ?? this.targetSavingAmount,
+      defaultContributionAmount:
+          defaultContributionAmount ?? this.defaultContributionAmount,
+      notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
+      bgmVolume: bgmVolume ?? this.bgmVolume,
+    );
+  }
+}

--- a/lib/models/transaction_history_state.dart
+++ b/lib/models/transaction_history_state.dart
@@ -1,0 +1,36 @@
+class TransactionHistoryState {
+  final List<Map<String, dynamic>> transactionHistory;
+  final int targetSavingAmount;
+  final int currentYear;
+  final int currentMonth;
+  final DateTime selectedDate; // ★追加: タップされた日付
+  final List<Map<String, dynamic>> selectedDateTransactions; // ★追加: タップされた日付の履歴
+
+  TransactionHistoryState({
+    this.transactionHistory = const [],
+    this.targetSavingAmount = 0,
+    required this.currentYear,
+    required this.currentMonth,
+    required this.selectedDate,
+    required this.selectedDateTransactions,
+  });
+
+  TransactionHistoryState copyWith({
+    List<Map<String, dynamic>>? transactionHistory,
+    int? targetSavingAmount,
+    int? currentYear,
+    int? currentMonth,
+    DateTime? selectedDate,
+    List<Map<String, dynamic>>? selectedDateTransactions,
+  }) {
+    return TransactionHistoryState(
+      transactionHistory: transactionHistory ?? this.transactionHistory,
+      targetSavingAmount: targetSavingAmount ?? this.targetSavingAmount,
+      currentYear: currentYear ?? this.currentYear,
+      currentMonth: currentMonth ?? this.currentMonth,
+      selectedDate: selectedDate ?? this.selectedDate,
+      selectedDateTransactions:
+          selectedDateTransactions ?? this.selectedDateTransactions,
+    );
+  }
+}

--- a/lib/models/tribute_history_state.dart
+++ b/lib/models/tribute_history_state.dart
@@ -1,0 +1,29 @@
+import 'package:uuid/uuid.dart';
+
+class TributeHistoryState {
+  final Uuid id;
+  final String character;
+  final DateTime date;
+  final int amount;
+
+  TributeHistoryState({
+    required this.id,
+    required this.character,
+    required this.date,
+    required this.amount,
+  });
+
+  TributeHistoryState copyWith({
+    Uuid? id,
+    String? character,
+    DateTime? date,
+    int? amount,
+  }) {
+    return TributeHistoryState(
+      id: id ?? this.id,
+      character: character ?? this.character,
+      date: date ?? this.date,
+      amount: amount ?? this.amount,
+    );
+  }
+}

--- a/lib/providers/home_screen_provider.dart
+++ b/lib/providers/home_screen_provider.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
-import '../providers/tribute_history_provider.dart';
 
 // 1. LocalStorageServiceを提供するシンプルなProvider
 

--- a/lib/providers/likeability_provider.dart
+++ b/lib/providers/likeability_provider.dart
@@ -1,0 +1,48 @@
+import 'dart:math';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:saving_girlfriend/providers/setting_provider.dart';
+import 'package:saving_girlfriend/providers/tribute_history_provider.dart';
+
+final likeabilityProvider = Provider<AsyncValue<double>>((ref) {
+  final settingsAsync = ref.watch(settingsProvider);
+  final tributeHistoryAsync = ref.watch(tributeHistoryProvider);
+
+  // 依存先のどちらかがロード中またはエラーの場合、それをそのまま伝える
+  if (settingsAsync.isLoading || tributeHistoryAsync.isLoading) {
+    return const AsyncValue.loading();
+  }
+  if (settingsAsync.hasError) {
+    return AsyncValue.error(settingsAsync.error!, settingsAsync.stackTrace!);
+  }
+  if (tributeHistoryAsync.hasError) {
+    return AsyncValue.error(
+        tributeHistoryAsync.error!, tributeHistoryAsync.stackTrace!);
+  }
+
+  // 依存先のデータが両方とも利用可能な場合、計算を実行する
+  final settings = settingsAsync.value!;
+  final history = tributeHistoryAsync.value!;
+
+  final int totalTribute = history.fold(0, (sum, item) => sum + item.amount);
+  final int targetAmount = settings.targetSavingAmount;
+  final int initialAmount = settings.defaultContributionAmount;
+
+  // 計算式に基づいて好感度を算出する
+  final int goalToSave = targetAmount - initialAmount;
+
+  // もう達成している場合は、達成率を100%として扱う
+  if (goalToSave <= 0) {
+    return const AsyncValue.data(100.0);
+  }
+
+  // 達成率を計算
+  final double progressRatio = totalTribute / goalToSave;
+
+  // 達成率がマイナスにならないように0で下限を設定
+  final double clampedRatio = max(0.0, progressRatio);
+
+  // --- 好感度の計算 ---
+  final double likeability = 100 * sqrt(clampedRatio);
+
+  return AsyncValue.data(likeability);
+});

--- a/lib/providers/setting_provider.dart
+++ b/lib/providers/setting_provider.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:saving_girlfriend/models/settings_state.dart';
+import 'package:saving_girlfriend/repositories/settings_repository.dart';
+import 'package:saving_girlfriend/services/local_storage_service.dart';
+
+class SettingNotifier extends AsyncNotifier<SettingsState> {
+  Future<SettingsRepository> get _settingsRepositoryFuture =>
+      ref.read(settingsRepositoryProvider.future);
+  @override
+  Future<SettingsState> build() async {
+    final settingsRepository = await _settingsRepositoryFuture;
+    return settingsRepository.getSettings();
+  }
+}
+
+final settingsRepositoryProvider =
+    FutureProvider<SettingsRepository>((ref) async {
+  final localStorageService =
+      await ref.watch(localStorageServiceProvider.future);
+  return SettingsRepository(localStorageService);
+});
+
+final settingsProvider = AsyncNotifierProvider<SettingNotifier, SettingsState>(
+  SettingNotifier.new,
+);

--- a/lib/providers/transaction_history_provider.dart
+++ b/lib/providers/transaction_history_provider.dart
@@ -1,0 +1,152 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:saving_girlfriend/models/settings_state.dart';
+import 'package:saving_girlfriend/models/transaction_history_state.dart';
+import 'package:saving_girlfriend/providers/setting_provider.dart';
+import 'package:saving_girlfriend/repositories/settings_repository.dart';
+import 'package:saving_girlfriend/repositories/transaction_history_repository.dart';
+import 'package:saving_girlfriend/services/local_storage_service.dart';
+
+class TransactionHistoryNotifier
+    extends AsyncNotifier<TransactionHistoryState> {
+  Future<TransactionHistoryRepository>
+      get _transactionHistoryRepositoryFuture =>
+          ref.read(transactionHistoryRepositoryProvider.future);
+  Future<SettingsRepository> get _settingsRepositoryFuture =>
+      ref.read(settingsRepositoryProvider.future);
+  @override
+  Future<TransactionHistoryState> build() async {
+    final transactionHistoryRepository =
+        await _transactionHistoryRepositoryFuture;
+    final history = await transactionHistoryRepository.getTransactionHistory();
+    final settingsRepository = await _settingsRepositoryFuture;
+    SettingsState settingsState = await settingsRepository.getSettings();
+    final int target = settingsState.targetSavingAmount;
+
+    // 初期値を設定する
+    final now = DateTime.now();
+    final todaysTransactions = history.where((transaction) {
+      final transactionDate = DateTime.parse(transaction['date']);
+      return transactionDate.year == now.year &&
+          transactionDate.month == now.month &&
+          transactionDate.day == now.day;
+    }).toList();
+
+    return TransactionHistoryState(
+      transactionHistory: history,
+      targetSavingAmount: target,
+      currentYear: now.year,
+      currentMonth: now.month,
+      selectedDate: now, // ★今日のデータを初期値に
+      selectedDateTransactions: todaysTransactions, // ★今日の履歴を初期値に
+    );
+  }
+
+  void changeMonth(int direction) {
+    final currentState = state.value!;
+
+    int newMonth = currentState.currentMonth + direction;
+    int newYear = currentState.currentYear;
+
+    if (newMonth > 12) {
+      newMonth = 1;
+      newYear++;
+    } else if (newMonth < 1) {
+      newMonth = 12;
+      newYear--;
+    }
+
+    state = AsyncData(currentState.copyWith(
+      currentYear: newYear,
+      currentMonth: newMonth,
+    ));
+  }
+
+  void selectDate(DateTime date) {
+    final currentState = state.value;
+    if (currentState == null) return;
+
+    // 全履歴の中から、選択された日付と一致するものだけをフィルタリング
+    final filteredTransactions =
+        currentState.transactionHistory.where((transaction) {
+      final transactionDate = DateTime.parse(transaction['date']);
+      return transactionDate.year == date.year &&
+          transactionDate.month == date.month &&
+          transactionDate.day == date.day;
+    }).toList();
+
+    // 状態を更新してUIに通知
+    state = AsyncData(currentState.copyWith(
+      selectedDate: date,
+      selectedDateTransactions: filteredTransactions,
+    ));
+  }
+
+  Future<void> addTransaction(Map<String, dynamic> newTransaction) async {
+    final currentState = state.value;
+    if (currentState == null) return;
+
+    final currentHistory =
+        List<Map<String, dynamic>>.from(currentState.transactionHistory);
+    // ★ idがなければ付与する
+    final transactionWithId = {
+      ...newTransaction,
+      'id': newTransaction['id'] ??
+          'transaction_${DateTime.now().millisecondsSinceEpoch}',
+    };
+
+    currentHistory.add(transactionWithId);
+    final transactionHistoryRepository =
+        await _transactionHistoryRepositoryFuture;
+    await transactionHistoryRepository.saveTransactionHistory(currentHistory);
+
+    final newState = currentState.copyWith(
+      transactionHistory: currentHistory,
+    );
+    state = AsyncData(newState);
+    selectDate(newState.selectedDate);
+  }
+
+  Future<void> updateTransaction(
+      String id, Map<String, dynamic> updatedTransaction) async {
+    final currentState = state.value;
+    if (currentState == null) return;
+    final currentHistory =
+        List<Map<String, dynamic>>.from(currentState.transactionHistory);
+    final index =
+        currentHistory.indexWhere((transaction) => transaction['id'] == id);
+
+    if (index != -1) {
+      currentHistory[index] = updatedTransaction;
+      final transactionHistoryRepository =
+          await _transactionHistoryRepositoryFuture;
+      await transactionHistoryRepository.saveTransactionHistory(currentHistory);
+
+      final newState = currentState.copyWith(
+        transactionHistory: currentHistory,
+      );
+      state = AsyncData(newState);
+      selectDate(newState.selectedDate);
+    }
+  }
+}
+
+final transactionHistoryProvider =
+    AsyncNotifierProvider<TransactionHistoryNotifier, TransactionHistoryState>(
+        () {
+  return TransactionHistoryNotifier();
+});
+
+final selectedTransactionsProvider =
+    Provider<List<Map<String, dynamic>>>((ref) {
+  final transactions = ref.watch(transactionHistoryProvider.select(
+    (asyncState) => asyncState.value?.selectedDateTransactions ?? [],
+  ));
+  return transactions;
+});
+
+final transactionHistoryRepositoryProvider =
+    FutureProvider<TransactionHistoryRepository>((ref) async {
+  final localStorageService =
+      await ref.watch(localStorageServiceProvider.future);
+  return TransactionHistoryRepository(localStorageService);
+});

--- a/lib/providers/tribute_history_provider.dart
+++ b/lib/providers/tribute_history_provider.dart
@@ -1,169 +1,74 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../services/local_storage_service.dart';
+import 'package:saving_girlfriend/models/tribute_history_state.dart';
+import 'package:saving_girlfriend/providers/uuid_provider.dart';
+import 'package:saving_girlfriend/repositories/tribute_history_repository.dart';
+import 'package:saving_girlfriend/services/local_storage_service.dart';
+import 'package:uuid/uuid.dart';
 
-// --- ① UIに表示するデータ（お皿）の定義 ---
-// この部分は generator を使う場合と全く同じです。
-class TributeHistoryState {
-  final List<Map<String, dynamic>> tributeHistory;
-  final int targetSavingAmount;
-  final int currentYear;
-  final int currentMonth;
-  final DateTime selectedDate; // ★追加: タップされた日付
-  final List<Map<String, dynamic>> selectedDateTributes; // ★追加: タップされた日付の履歴
-
-  TributeHistoryState({
-    this.tributeHistory = const [],
-    this.targetSavingAmount = 0,
-    required this.currentYear,
-    required this.currentMonth,
-    required this.selectedDate,
-    required this.selectedDateTributes,
-  });
-
-  TributeHistoryState copyWith({
-    List<Map<String, dynamic>>? tributeHistory,
-    int? targetSavingAmount,
-    int? currentYear,
-    int? currentMonth,
-    DateTime? selectedDate,
-    List<Map<String, dynamic>>? selectedDateTributes,
-  }) {
-    return TributeHistoryState(
-      tributeHistory: tributeHistory ?? this.tributeHistory,
-      targetSavingAmount: targetSavingAmount ?? this.targetSavingAmount,
-      currentYear: currentYear ?? this.currentYear,
-      currentMonth: currentMonth ?? this.currentMonth,
-      selectedDate: selectedDate ?? this.selectedDate,
-      selectedDateTributes: selectedDateTributes ?? this.selectedDateTributes,
-    );
-  }
-}
-
-final localStorageServiceProvider = Provider<LocalStorageService>((ref) {
-  return LocalStorageService();
+// TributeHistoryNotifier を提供する
+final tributeHistoryProvider = StateNotifierProvider<TributeHistoryNotifier,
+    AsyncValue<List<TributeHistoryState>>>((ref) {
+  final repository = ref.watch(tributeHistoryRepositoryProvider.future);
+  final uuid = ref.watch(uuidProvider);
+  return TributeHistoryNotifier(repository, uuid);
 });
 
-// --- ② データを操作するロジック（お料理人）の定義 ---
-class TributeHistoryNotifier extends AsyncNotifier<TributeHistoryState> {
-  @override
-  Future<TributeHistoryState> build() async {
-    final localStorageService = LocalStorageService();
-    final history = await localStorageService.getTributeHistory();
-    final target = await localStorageService.getTargetSavingAmount() ?? 0;
-
-    // ★buildメソッドで、今日の履歴を初期値として設定する
-    final now = DateTime.now();
-    final todaysTributes = history.where((tribute) {
-      final tributeDate = DateTime.parse(tribute['date']);
-      return tributeDate.year == now.year &&
-          tributeDate.month == now.month &&
-          tributeDate.day == now.day;
-    }).toList();
-
-    return TributeHistoryState(
-      tributeHistory: history,
-      targetSavingAmount: target,
-      currentYear: now.year,
-      currentMonth: now.month,
-      selectedDate: now, // ★今日のデータを初期値に
-      selectedDateTributes: todaysTributes, // ★今日の履歴を初期値に
-    );
+// 貢ぎ履歴の状態を管理する StateNotifier
+class TributeHistoryNotifier
+    extends StateNotifier<AsyncValue<List<TributeHistoryState>>> {
+  TributeHistoryNotifier(this._repositoryFuture, this._uuid)
+      : super(const AsyncValue.loading()) {
+    getTributionHistory();
   }
 
-  void changeMonth(int direction) {
-    final currentState = state.value!;
+  final Future<TributeHistoryRepository> _repositoryFuture;
+  final Uuid _uuid;
 
-    int newMonth = currentState.currentMonth + direction;
-    int newYear = currentState.currentYear;
-
-    if (newMonth > 12) {
-      newMonth = 1;
-      newYear++;
-    } else if (newMonth < 1) {
-      newMonth = 12;
-      newYear--;
-    }
-
-    state = AsyncData(currentState.copyWith(
-      currentYear: newYear,
-      currentMonth: newMonth,
-    ));
-  }
-
-  Future<void> addTribute(Map<String, dynamic> newTribute) async {
-    final localStorageService = ref.read(localStorageServiceProvider);
-    final currentHistory =
-        List<Map<String, dynamic>>.from(state.value!.tributeHistory);
-    // ★ idがなければ付与する
-    final tributeWithId = {
-      ...newTribute,
-      'id': newTribute['id'] ??
-          'tribute_${DateTime.now().millisecondsSinceEpoch}',
-    };
-
-    currentHistory.add(tributeWithId);
-    await localStorageService.saveTributeHistory(currentHistory);
-
-    final newState = state.value!.copyWith(
-      tributeHistory: currentHistory,
-    );
-    state = AsyncData(newState);
-    selectDate(newState.selectedDate);
-  }
-
-  Future<void> updateTribute(
-      String id, Map<String, dynamic> updatedTribute) async {
-    final localStorageService = ref.read(localStorageServiceProvider);
-    // state.value! で現在の状態（データ）を安全に取得
-    final currentHistory =
-        List<Map<String, dynamic>>.from(state.value!.tributeHistory);
-
-    // 更新対象の履歴をIDで探す
-    final index = currentHistory.indexWhere((tribute) => tribute['id'] == id);
-
-    // もし見つかったら
-    if (index != -1) {
-      // 新しいデータで置き換える
-      currentHistory[index] = updatedTribute;
-      // 保存する
-      await localStorageService.saveTributeHistory(currentHistory);
-
-      // アプリの状態を更新して、画面に即時反映させる
-      state = AsyncData(state.value!.copyWith(
-        tributeHistory: currentHistory,
-      ));
+  // 履歴を非同期に読み込む
+  Future<void> getTributionHistory() async {
+    state = const AsyncValue.loading();
+    try {
+      final repository = await _repositoryFuture;
+      final history = await repository.getTributionHistory();
+      state = AsyncValue.data(history);
+    } catch (e, s) {
+      state = AsyncValue.error(e, s);
     }
   }
 
-  void selectDate(DateTime date) {
+  /// 新しい貢ぎ物を追加する
+  Future<void> add({
+    required String character,
+    required String itemName,
+    required int amount,
+  }) async {
     final currentState = state.value;
     if (currentState == null) return;
 
-    // 全履歴の中から、選択された日付と一致するものだけをフィルタリング
-    final filteredTributes = currentState.tributeHistory.where((tribute) {
-      final tributeDate = DateTime.parse(tribute['date']);
-      return tributeDate.year == date.year &&
-          tributeDate.month == date.month &&
-          tributeDate.day == date.day;
-    }).toList();
+    final newTribute = TributeHistoryState(
+      id: _uuid,
+      character: character,
+      amount: amount,
+      date: DateTime.now(),
+    );
 
-    // 状態を更新してUIに通知
-    state = AsyncData(currentState.copyWith(
-      selectedDate: date,
-      selectedDateTributes: filteredTributes,
-    ));
+    final newState = [...currentState, newTribute];
+    state = AsyncValue.data(newState);
+
+    try {
+      final repository = await _repositoryFuture;
+      await repository.saveTributionHistory(newState);
+    } catch (e) {
+      state = AsyncValue.data(currentState);
+      print('Failed to save tribute: $e');
+      //
+    }
   }
 }
 
-// --- ③ Provider（メニュー表）の定義 ---
-final tributeHistoryProvider =
-    AsyncNotifierProvider<TributeHistoryNotifier, TributeHistoryState>(() {
-  return TributeHistoryNotifier();
-});
-
-final selectedTributesProvider = Provider<List<Map<String, dynamic>>>((ref) {
-  final tributes = ref.watch(tributeHistoryProvider.select(
-    (asyncState) => asyncState.value?.selectedDateTributes ?? [],
-  ));
-  return tributes;
+final tributeHistoryRepositoryProvider =
+    FutureProvider<TributeHistoryRepository>((ref) async {
+  final localStorageService =
+      await ref.watch(localStorageServiceProvider.future);
+  return TributeHistoryRepository(localStorageService);
 });

--- a/lib/providers/uuid_provider.dart
+++ b/lib/providers/uuid_provider.dart
@@ -1,0 +1,4 @@
+import 'package:uuid/uuid.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final uuidProvider = Provider<Uuid>((ref) => const Uuid());

--- a/lib/repositories/settings_repository.dart
+++ b/lib/repositories/settings_repository.dart
@@ -1,0 +1,15 @@
+import 'package:saving_girlfriend/models/settings_state.dart';
+import '../services/local_storage_service.dart';
+
+class SettingsRepository {
+  final LocalStorageService _localStorageService;
+  SettingsRepository(this._localStorageService);
+
+  Future<SettingsState> getSettings() {
+    return _localStorageService.getSettings();
+  }
+
+  Future<void> saveSettings(SettingsState settings) {
+    return _localStorageService.saveSettings(settings);
+  }
+}

--- a/lib/repositories/transaction_history_repository.dart
+++ b/lib/repositories/transaction_history_repository.dart
@@ -1,0 +1,15 @@
+import '../services/local_storage_service.dart';
+
+class TransactionHistoryRepository {
+  final LocalStorageService _localStorageService;
+  TransactionHistoryRepository(this._localStorageService);
+
+  Future<void> saveTransactionHistory(
+      List<Map<String, dynamic>> history) async {
+    await _localStorageService.saveTransactionHistory(history);
+  }
+
+  Future<List<Map<String, dynamic>>> getTransactionHistory() async {
+    return _localStorageService.getTransactionHistory();
+  }
+}

--- a/lib/repositories/tribute_history_repository.dart
+++ b/lib/repositories/tribute_history_repository.dart
@@ -1,0 +1,15 @@
+import 'package:saving_girlfriend/models/tribute_history_state.dart';
+import 'package:saving_girlfriend/services/local_storage_service.dart';
+
+class TributeHistoryRepository {
+  final LocalStorageService _localStorageService;
+  TributeHistoryRepository(this._localStorageService);
+
+  Future<void> saveTributionHistory(List<TributeHistoryState> history) async {
+    await _localStorageService.saveTributionHistory(history);
+  }
+
+  Future<List<TributeHistoryState>> getTributionHistory() async {
+    return _localStorageService.getTributionHistory();
+  }
+}

--- a/lib/route/go_router.dart
+++ b/lib/route/go_router.dart
@@ -4,7 +4,7 @@ import 'package:saving_girlfriend/screen/select_girlfriend_screen.dart';
 import 'package:saving_girlfriend/screen/select_story_screen.dart';
 import 'package:saving_girlfriend/screen/story_screen.dart';
 import 'package:saving_girlfriend/screen/settings_screen.dart';
-import 'package:saving_girlfriend/screen/tribute_history_screen.dart';
+import 'package:saving_girlfriend/screen/transaction_history_screen.dart';
 import 'package:saving_girlfriend/screen/transaction_input_screen.dart';
 import 'app_navigation_bar.dart';
 import 'package:flutter/material.dart';
@@ -18,8 +18,8 @@ final selectStoryNavigatorKey =
     GlobalKey<NavigatorState>(debugLabel: 'select_story');
 final selectGirlfriendNavigatorKey =
     GlobalKey<NavigatorState>(debugLabel: 'select_girlfriend');
-final tributeHistoryNavigatorKey =
-    GlobalKey<NavigatorState>(debugLabel: 'tribute_history');
+final transactionHistoryNavigatorKey =
+    GlobalKey<NavigatorState>(debugLabel: 'transaction_history');
 // 新しい画面用のGlobalKeyを追加
 final transactionInputNavigatorKey =
     GlobalKey<NavigatorState>(debugLabel: 'transaction_input');
@@ -90,22 +90,25 @@ final router = GoRouter(
           ),
         ]),
         // 4. 貢ぎ履歴ブランチ
-        StatefulShellBranch(navigatorKey: tributeHistoryNavigatorKey, routes: [
-          GoRoute(
-            path: '/tribute_history',
-            pageBuilder: (context, state) => NoTransitionPage(
-              key: state.pageKey,
-              child: const TributeHistoryScreen(),
-            ),
-          ),
-        ]),
+        StatefulShellBranch(
+            navigatorKey: transactionHistoryNavigatorKey,
+            routes: [
+              GoRoute(
+                path: '/transaction_history',
+                pageBuilder: (context, state) => NoTransitionPage(
+                  key: state.pageKey,
+                  child: const TransactionHistoryScreen(),
+                ),
+              ),
+            ]),
       ],
     ),
     GoRoute(
       path: '/story',
       parentNavigatorKey: rootNavigatorKey,
       pageBuilder: (context, state) {
-        final story_index = state.extra is int ? state.extra as int : 0;;
+        final story_index = state.extra is int ? state.extra as int : 0;
+        ;
         return MaterialPage(child: StoryScreen(story_index: story_index));
       },
     )

--- a/lib/screen/home_screen.dart
+++ b/lib/screen/home_screen.dart
@@ -1,12 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:saving_girlfriend/constants/assets.dart';
 import '../constants/color.dart';
 import 'package:go_router/go_router.dart';
 import '../providers/home_screen_provider.dart';
-import 'package:intl/intl.dart';
-import 'package:saving_girlfriend/screen/settings_screen.dart';
+
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
 
@@ -52,7 +50,8 @@ class HomeScreen extends ConsumerWidget {
                   left: 20,
                   right: 20,
                   child: Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
                     decoration: BoxDecoration(
                       color: AppColors.mainBackground.withOpacity(0.8),
                       borderRadius: BorderRadius.circular(20),
@@ -62,14 +61,16 @@ class HomeScreen extends ConsumerWidget {
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
                         IconButton(
-                          icon: const Icon(Icons.settings, color: AppColors.subIcon),
+                          icon: const Icon(Icons.settings,
+                              color: AppColors.subIcon),
                           onPressed: () {
                             context.push('/home/settings');
                           },
                         ),
                         const Text(
                           '5回目継続中!!',
-                          style: TextStyle(color: AppColors.mainText, fontSize: 12),
+                          style: TextStyle(
+                              color: AppColors.mainText, fontSize: 12),
                         ),
                         const Expanded(
                           child: Padding(
@@ -77,13 +78,19 @@ class HomeScreen extends ConsumerWidget {
                             child: LinearProgressIndicator(
                               value: 0.5,
                               backgroundColor: AppColors.nonActive,
-                              valueColor: AlwaysStoppedAnimation<Color>(AppColors.primary),
+                              valueColor: AlwaysStoppedAnimation<Color>(
+                                  AppColors.primary),
                             ),
                           ),
                         ),
-                        const Icon(Icons.favorite, color: AppColors.primary, size: 18),
-                        const Text('50', style: TextStyle(color: AppColors.mainText, fontSize: 14)),
-                        const Text('/100', style: TextStyle(color: AppColors.mainText, fontSize: 12)),
+                        const Icon(Icons.favorite,
+                            color: AppColors.primary, size: 18),
+                        const Text('50',
+                            style: TextStyle(
+                                color: AppColors.mainText, fontSize: 14)),
+                        const Text('/100',
+                            style: TextStyle(
+                                color: AppColors.mainText, fontSize: 12)),
                       ],
                     ),
                   ),
@@ -109,7 +116,8 @@ class HomeScreen extends ConsumerWidget {
                       ),
                       child: Text(
                         girlfriendText,
-                        style: const TextStyle(fontSize: 14, color: AppColors.mainText),
+                        style: const TextStyle(
+                            fontSize: 14, color: AppColors.mainText),
                       ),
                     ),
                   ),
@@ -205,7 +213,8 @@ class _ChatInputWidgetState extends State<ChatInputWidget> {
               Expanded(
                 child: Container(
                   decoration: BoxDecoration(
-                    border: Border.all(color: theme.colorScheme.outline.withOpacity(0.3)),
+                    border: Border.all(
+                        color: theme.colorScheme.outline.withOpacity(0.3)),
                     borderRadius: BorderRadius.circular(24.0),
                     color: theme.colorScheme.background,
                   ),
@@ -216,7 +225,8 @@ class _ChatInputWidgetState extends State<ChatInputWidget> {
                     decoration: InputDecoration(
                       hintText: widget.hintText,
                       border: InputBorder.none,
-                      contentPadding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+                      contentPadding: const EdgeInsets.symmetric(
+                          horizontal: 16.0, vertical: 12.0),
                     ),
                     onChanged: (text) {
                       setState(() {
@@ -234,7 +244,9 @@ class _ChatInputWidgetState extends State<ChatInputWidget> {
                   shape: BoxShape.circle,
                 ),
                 child: IconButton(
-                  onPressed: _isComposing ? () => _handleSubmitted(_textController.text) : null,
+                  onPressed: _isComposing
+                      ? () => _handleSubmitted(_textController.text)
+                      : null,
                   icon: Icon(widget.sendIcon, color: AppColors.mainIcon),
                 ),
               ),

--- a/lib/screen/transaction_history_screen.dart
+++ b/lib/screen/transaction_history_screen.dart
@@ -3,15 +3,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:saving_girlfriend/constants/color.dart';
-import '../providers/tribute_history_provider.dart';
+import '../providers/transaction_history_provider.dart';
 
-class TributeHistoryScreen extends ConsumerWidget {
-  const TributeHistoryScreen({super.key});
+class TransactionHistoryScreen extends ConsumerWidget {
+  const TransactionHistoryScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final tributeHistoryAsync = ref.watch(tributeHistoryProvider);
-    final selectedTributes = ref.watch(selectedTributesProvider);
+    final transactionHistoryAsync = ref.watch(transactionHistoryProvider);
+    final selectedTransactions = ref.watch(selectedTransactionsProvider);
 
     // --- 金額フォーマット関数 ---
     String formatAmount(int amount) {
@@ -33,32 +33,36 @@ class TributeHistoryScreen extends ConsumerWidget {
       appBar: AppBar(
         backgroundColor: AppColors.secondary,
       ),
-      body: tributeHistoryAsync.when(
+      body: transactionHistoryAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (err, stack) => Center(child: Text('エラー: $err')),
         data: (state) {
           // --- 日別の合計献金金額を計算 ---
-          Map<String, int> calculateDailyTributes() {
-            final dailyTributes = <String, int>{};
-            for (var tribute in state.tributeHistory) {
-              final date = DateTime.parse(tribute['date']);
-              if (date.month == state.currentMonth && date.year == state.currentYear) {
+          Map<String, int> calculateDailyTransactions() {
+            final dailyTransaction = <String, int>{};
+            for (var transaction in state.transactionHistory) {
+              final date = DateTime.parse(transaction['date']);
+              if (date.month == state.currentMonth &&
+                  date.year == state.currentYear) {
                 final formattedDate = DateFormat('yyyy-MM-dd').format(date);
-                dailyTributes[formattedDate] =
-                    (dailyTributes[formattedDate] ?? 0) + (tribute['amount'] as int);
+                dailyTransaction[formattedDate] =
+                    (dailyTransaction[formattedDate] ?? 0) +
+                        (transaction['amount'] as int);
               }
             }
-            return dailyTributes;
+            return dailyTransaction;
           }
 
-          int getDaysInMonth() => DateTime(state.currentYear, state.currentMonth + 1, 0).day;
+          int getDaysInMonth() =>
+              DateTime(state.currentYear, state.currentMonth + 1, 0).day;
 
           int getStartDayOfMonth() {
-            final weekday = DateTime(state.currentYear, state.currentMonth, 1).weekday;
+            final weekday =
+                DateTime(state.currentYear, state.currentMonth, 1).weekday;
             return weekday == 7 ? 0 : weekday;
           }
 
-          final dailyTributes = calculateDailyTributes();
+          final dailyTransaction = calculateDailyTransactions();
 
           return Column(
             children: [
@@ -84,16 +88,23 @@ class TributeHistoryScreen extends ConsumerWidget {
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
                         IconButton(
-                          icon: const Icon(Icons.chevron_left, color: AppColors.primary),
-                          onPressed: () => ref.read(tributeHistoryProvider.notifier).changeMonth(-1),
+                          icon: const Icon(Icons.chevron_left,
+                              color: AppColors.primary),
+                          onPressed: () => ref
+                              .read(transactionHistoryProvider.notifier)
+                              .changeMonth(-1),
                         ),
                         Text(
                           '${state.currentYear}年 ${state.currentMonth}月',
-                          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                          style: const TextStyle(
+                              fontSize: 18, fontWeight: FontWeight.bold),
                         ),
                         IconButton(
-                          icon: const Icon(Icons.chevron_right, color: AppColors.primary),
-                          onPressed: () => ref.read(tributeHistoryProvider.notifier).changeMonth(1),
+                          icon: const Icon(Icons.chevron_right,
+                              color: AppColors.primary),
+                          onPressed: () => ref
+                              .read(transactionHistoryProvider.notifier)
+                              .changeMonth(1),
                         ),
                       ],
                     ),
@@ -119,18 +130,23 @@ class TributeHistoryScreen extends ConsumerWidget {
                       shrinkWrap: true,
                       physics: const NeverScrollableScrollPhysics(),
                       gridDelegate:
-                          const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 7),
+                          const SliverGridDelegateWithFixedCrossAxisCount(
+                              crossAxisCount: 7),
                       itemCount: getDaysInMonth() + getStartDayOfMonth(),
                       itemBuilder: (context, index) {
                         final startDay = getStartDayOfMonth();
                         final day = index - startDay + 1;
-                        final isCurrentMonthDay = day > 0 && day <= getDaysInMonth();
+                        final isCurrentMonthDay =
+                            day > 0 && day <= getDaysInMonth();
 
                         return GestureDetector(
                           onTap: () {
                             if (isCurrentMonthDay) {
-                              final date = DateTime(state.currentYear, state.currentMonth, day);
-                              ref.read(tributeHistoryProvider.notifier).selectDate(date);
+                              final date = DateTime(
+                                  state.currentYear, state.currentMonth, day);
+                              ref
+                                  .read(transactionHistoryProvider.notifier)
+                                  .selectDate(date);
                             }
                           },
                           child: Container(
@@ -140,7 +156,8 @@ class TributeHistoryScreen extends ConsumerWidget {
                                 color: isCurrentMonthDay &&
                                         DateUtils.isSameDay(
                                             state.selectedDate,
-                                            DateTime(state.currentYear, state.currentMonth, day))
+                                            DateTime(state.currentYear,
+                                                state.currentMonth, day))
                                     ? AppColors.primary
                                     : Colors.transparent,
                                 width: 2,
@@ -151,15 +168,22 @@ class TributeHistoryScreen extends ConsumerWidget {
                                 ? Column(
                                     mainAxisAlignment: MainAxisAlignment.center,
                                     children: [
-                                      Text(day.toString(), style: const TextStyle(fontSize: 12)),
-                                      if (dailyTributes.containsKey(DateFormat('yyyy-MM-dd')
-                                          .format(DateTime(state.currentYear, state.currentMonth, day))))
+                                      Text(day.toString(),
+                                          style: const TextStyle(fontSize: 12)),
+                                      if (dailyTransaction.containsKey(
+                                          DateFormat('yyyy-MM-dd').format(
+                                              DateTime(state.currentYear,
+                                                  state.currentMonth, day))))
                                         Text(
-                                          formatAmount(dailyTributes[DateFormat('yyyy-MM-dd')
-                                              .format(DateTime(
-                                                  state.currentYear, state.currentMonth, day))]!),
+                                          formatAmount(dailyTransaction[
+                                              DateFormat('yyyy-MM-dd').format(
+                                                  DateTime(
+                                                      state.currentYear,
+                                                      state.currentMonth,
+                                                      day))]!),
                                           style: const TextStyle(
-                                              fontSize: 10, color: AppColors.primary),
+                                              fontSize: 10,
+                                              color: AppColors.primary),
                                           overflow: TextOverflow.ellipsis,
                                         ),
                                     ],
@@ -180,26 +204,30 @@ class TributeHistoryScreen extends ConsumerWidget {
                   alignment: Alignment.centerLeft,
                   child: Text(
                     '${DateFormat('yyyy年MM月dd日').format(state.selectedDate)}の履歴',
-                    style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                    style: const TextStyle(
+                        fontSize: 16, fontWeight: FontWeight.bold),
                   ),
                 ),
               ),
               Expanded(
-                child: selectedTributes.isEmpty
+                child: selectedTransactions.isEmpty
                     ? const Center(child: Text('この日の履歴はありません。'))
                     : ListView.builder(
                         padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                        itemCount: selectedTributes.length,
+                        itemCount: selectedTransactions.length,
                         itemBuilder: (context, index) {
-                          final tribute = selectedTributes[index];
-                          final amount = tribute['amount'] as int;
-                          final category = tribute['category'] as String? ?? 'カテゴリなし';
+                          final transaction = selectedTransactions[index];
+                          final amount = transaction['amount'] as int;
+                          final category =
+                              transaction['category'] as String? ?? 'カテゴリなし';
                           return Card(
                             elevation: 1,
                             margin: const EdgeInsets.symmetric(vertical: 4),
                             child: ListTile(
                               leading: Icon(
-                                amount >= 0 ? Icons.arrow_upward : Icons.arrow_downward,
+                                amount >= 0
+                                    ? Icons.arrow_upward
+                                    : Icons.arrow_downward,
                                 color: amount >= 0 ? Colors.green : Colors.red,
                               ),
                               title: Text(category),
@@ -209,21 +237,29 @@ class TributeHistoryScreen extends ConsumerWidget {
                                   Text(
                                     formatAmount(amount), // k/m表記に変換
                                     style: TextStyle(
-                                      color: amount >= 0 ? Colors.green : Colors.red,
+                                      color: amount >= 0
+                                          ? Colors.green
+                                          : Colors.red,
                                       fontWeight: FontWeight.bold,
                                     ),
                                   ),
                                   const SizedBox(width: 8),
                                   IconButton(
-                                    icon: const Icon(Icons.edit, size: 20, color: Colors.grey),
+                                    icon: const Icon(Icons.edit,
+                                        size: 20, color: Colors.grey),
                                     onPressed: () {
                                       showTransactionModal(
                                         context,
                                         onSave: (updatedData) {
-                                          final tributeId = updatedData['id'] as String;
-                                          ref.read(tributeHistoryProvider.notifier).updateTribute(tributeId, updatedData);
+                                          final TransactionId =
+                                              updatedData['id'] as String;
+                                          ref
+                                              .read(transactionHistoryProvider
+                                                  .notifier)
+                                              .updateTransaction(
+                                                  TransactionId, updatedData);
                                         },
-                                        initialTribute: tribute,
+                                        initialTransaction: transaction,
                                       );
                                     },
                                   ),

--- a/lib/screen/transaction_input_screen.dart
+++ b/lib/screen/transaction_input_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:saving_girlfriend/constants/color.dart';
 import '../providers/home_screen_provider.dart';
-import '../providers/tribute_history_provider.dart';
+import '../providers/transaction_history_provider.dart';
 import 'package:flutter/services.dart';
 
 class TransactionInputScreen extends ConsumerStatefulWidget {
@@ -65,15 +65,18 @@ class _TransactionInputScreenState
       return;
     }
 
-    final newTribute = {
-      "character": "A",
+    // ここを修正する
+    final newTransaction = {
+      "type": _isExpense ? "expense" : "income",
       "date": _selectedDate.toIso8601String(),
-      "amount": _isExpense ? -amount : amount,
+      "amount": amount,
       "category": _selectedCategory!,
     };
 
     try {
-      await ref.read(tributeHistoryProvider.notifier).addTribute(newTribute);
+      await ref
+          .read(transactionHistoryProvider.notifier)
+          .addTransaction(newTransaction);
 
       ref
           .read(homeScreenProvider.notifier)
@@ -91,7 +94,12 @@ class _TransactionInputScreenState
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
-          content: Text('データの保存に失敗しました。もう一度お試しください。'),
+          content: Text(
+            'データの保存に失敗しました。もう一度お試しください。',
+            style: TextStyle(
+              color: AppColors.error, // ここで色を指定します
+            ),
+          ),
           backgroundColor: AppColors.errorBackground,
         ),
       );

--- a/lib/services/local_storage_service.dart
+++ b/lib/services/local_storage_service.dart
@@ -1,14 +1,29 @@
 import 'dart:convert';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:saving_girlfriend/models/settings_state.dart';
+import 'package:saving_girlfriend/models/tribute_history_state.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
+
+final sharedPreferencesProvider =
+    FutureProvider<SharedPreferences>((ref) async {
+  return SharedPreferences.getInstance();
+});
+final localStorageServiceProvider =
+    FutureProvider<LocalStorageService>((ref) async {
+  final sharedPreferences = await ref.watch(sharedPreferencesProvider.future);
+  return LocalStorageService(sharedPreferences);
+});
 
 class LocalStorageService {
-  // インスタンスは最初に取得する
-  static late SharedPreferences prefs;
-  static const String _userIdKey = 'user_id';
-  // 各データのキーを定数として定義しておくとタイプミスを防げます
+  final SharedPreferences _prefs;
+  LocalStorageService(this._prefs);
+
+  // static const String _userIdKey = 'user_id';
   static const String _currentCharacterKey = 'current_character';
   static const String _likeabilityKeyPrefix = '_likeability'; // キャラごとに好感度を保存
-  static const String _tributeHistoryKey = 'tribute_history';
+  static const String _transactionHistoryKey = 'transaction_history';
+  static const String _tributionHistoryKey = 'tribution_history';
   static const String _targetSavingAmountKey = 'target_saving_amount';
   static const String _defaultContributionAmountKey =
       'default_contribution_amount';
@@ -17,95 +32,107 @@ class LocalStorageService {
 
   // --- 保存 (Save) ---
 
-  static Future<void> init() async {
-    prefs = await SharedPreferences.getInstance();
-  }
-
-/// ユーザーIDを保存する
-  Future<void> saveUserId(String userId) async {
-    await prefs.setString(_userIdKey, userId);
-  }
-
-  /// ユーザーIDを読み込む
-  Future<String?> getUserId() async {
-    return prefs.getString(_userIdKey);
-  }
-
   Future<void> saveCurrentCharacter(String characterId) async {
-    await prefs.setString(_currentCharacterKey, characterId);
+    await _prefs.setString(_currentCharacterKey, characterId);
   }
 
-  Future<void> saveLikeability(String characterId, int value) async {
-    await prefs.setInt('$characterId$_likeabilityKeyPrefix', value);
-  }
-
-  Future<void> saveTributeHistory(List<Map<String, dynamic>> history) async {
+  Future<void> saveTransactionHistory(
+      List<Map<String, dynamic>> history) async {
     String jsonString = jsonEncode(history);
-    await prefs.setString(_tributeHistoryKey, jsonString);
+    await _prefs.setString(_transactionHistoryKey, jsonString);
   }
 
-  Future<void> saveSettings({
-    required int targetSavingAmount,
-    required int defaultContributionAmount,
-    required bool notificationsEnabled,
-    required double bgmVolume,
-  }) async {
-    await prefs.setInt(_targetSavingAmountKey, targetSavingAmount);
-    await prefs.setInt(
-        _defaultContributionAmountKey, defaultContributionAmount);
-    await prefs.setBool(_notificationsEnabledKey, notificationsEnabled);
-    await prefs.setDouble(_bgmVolumeKey, bgmVolume);
+  Future<void> saveTributionHistory(List<TributeHistoryState> history) async {
+    String jsonString = jsonEncode(history);
+    await _prefs.setString(_tributionHistoryKey, jsonString);
+  }
+
+  Future<void> saveSettings(SettingsState setting) async {
+    await _prefs.setInt(_targetSavingAmountKey, setting.targetSavingAmount);
+    await _prefs.setInt(
+        _defaultContributionAmountKey, setting.defaultContributionAmount);
+    await _prefs.setBool(
+        _notificationsEnabledKey, setting.notificationsEnabled);
+    await _prefs.setDouble(_bgmVolumeKey, setting.bgmVolume);
   }
 
   // --- 読み込み (Load) ---
 
   Future<String?> getCurrentCharacter() async {
-    return prefs.getString(_currentCharacterKey);
+    return _prefs.getString(_currentCharacterKey);
   }
 
   Future<int> getLikeability(String characterId) async {
-    // 保存されていない場合の初期値は 50 などに設定
-    return prefs.getInt('$characterId$_likeabilityKeyPrefix') ?? 50;
+    // ここを書き換える
+    return _prefs.getInt('$characterId$_likeabilityKeyPrefix') ?? 1;
   }
 
-  Future<List<Map<String, dynamic>>> getTributeHistory() async {
-    final jsonString = prefs.getString(_tributeHistoryKey);
+  Future<List<Map<String, dynamic>>> getTransactionHistory() async {
+    final jsonString = _prefs.getString(_transactionHistoryKey);
     if (jsonString != null && jsonString.isNotEmpty) {
       final List<dynamic> decodedList = jsonDecode(jsonString);
-      print(decodedList.map((item) => Map<String, dynamic>.from(item)).toList());
-      return decodedList
-          .map((item) => Map<String, dynamic>.from(item))
-          .toList();
+      final result =
+          decodedList.map((item) => Map<String, dynamic>.from(item)).toList();
+      print(result);
+      return result;
     }
     // データがない場合は空のリストを返す
     return [];
   }
 
-  Future<int?> getTargetSavingAmount() async {
-    return prefs.getInt(_targetSavingAmountKey);
+  Future<List<TributeHistoryState>> getTributionHistory() async {
+    final jsonString = _prefs.getString(_tributionHistoryKey);
+    if (jsonString != null && jsonString.isNotEmpty) {
+      final List<dynamic> decodedList = jsonDecode(jsonString);
+      final List<TributeHistoryState> result = decodedList
+          .map((item) => TributeHistoryState(
+              id: item["id"] as Uuid,
+              character: item["character"] as String,
+              date: item["date"] as DateTime,
+              amount: item["amount"] as int))
+          .toList();
+      print(result);
+      return result;
+    }
+    // データがない場合は空のリストを返す
+    return [];
   }
 
-  Future<int?> getDefaultContributionAmount() async {
-    return prefs.getInt(_defaultContributionAmountKey);
-  }
-
-  Future<bool> getNotificationsEnabled() async {
-    return prefs.getBool(_notificationsEnabledKey) ?? true; // Default to true
-  }
-
-  Future<double> getBgmVolume() async {
-    return prefs.getDouble(_bgmVolumeKey) ?? 0.75; // Default to 0.75
+  Future<SettingsState> getSettings() async {
+    final int targetSavingAmount =
+        _prefs.getInt(_targetSavingAmountKey) ?? 100000;
+    final int defaultContributionAmount =
+        _prefs.getInt(_defaultContributionAmountKey) ?? 500;
+    final bool notificationsEnabled =
+        _prefs.getBool(_notificationsEnabledKey) ?? true;
+    final double bgmVolume = _prefs.getDouble(_bgmVolumeKey) ?? 0.75;
+    return SettingsState(
+        targetSavingAmount: targetSavingAmount,
+        defaultContributionAmount: defaultContributionAmount,
+        notificationsEnabled: notificationsEnabled,
+        bgmVolume: bgmVolume);
   }
 }
 
 // <データ設計>
 // current_character: "characterA" (String)
 // characterA_likeability: 85(int)
+// transaction_history
 // [
-//   {"character": "A", "date": "2024-06-25", "amount": 1000},
-//   {"character": "B", "date": "2024-06-26", "amount": 500}
+//   {"type": "income", "date": "2024-06-25", "amount": 50000, "category": category},
+//   {"type": "expense", "date": "2024-06-25", "amount": 1000, "category": category},
+//   {"type": "expense", "date": "2024-06-26", "amount": 500, "category": category},
 // ]List<String>
+// tribute_history
+// [
+//  {"id": 0101101001..., "character": "SuzunariOto", "date": "2024-06-25", "amount": 500},
+//  {"id": 0101101001..., "character": "SuzunariOto", "date": "2024-06-25", "amount": 500},
+//  {"id": 0101101001..., "character": "SuzunariOto", "date": "2024-06-25", "amount": 500},
+// ]
+
 // target_saving_amount: 100000 (int)
 // default_contribution_amount: 500 (int)
+// added_saging_amount: 20000 (int)
+
 // notifications_enabled: true (bool)
 // bgm_volume: 0.75 (double)

--- a/lib/widgets/transaction_modal.dart
+++ b/lib/widgets/transaction_modal.dart
@@ -6,7 +6,7 @@ import 'package:saving_girlfriend/constants/color.dart';
 void showTransactionModal(
   BuildContext context, {
   required Function(Map<String, dynamic>) onSave,
-  Map<String, dynamic>? initialTribute,
+  Map<String, dynamic>? initialTransaction,
 }) {
   showModalBottomSheet(
     context: context,
@@ -16,10 +16,11 @@ void showTransactionModal(
     ),
     builder: (BuildContext context) {
       return Padding(
-        padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+        padding:
+            EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
         child: TransactionInputModal(
           onSave: onSave,
-          initialTribute: initialTribute,
+          initialTransaction: initialTransaction,
         ),
       );
     },
@@ -29,13 +30,10 @@ void showTransactionModal(
 // 収支入力モーダルのUIを定義するStatefulWidget
 class TransactionInputModal extends StatefulWidget {
   final Function(Map<String, dynamic>) onSave;
-  final Map<String, dynamic>? initialTribute;
+  final Map<String, dynamic>? initialTransaction;
 
-  const TransactionInputModal({
-    required this.onSave,
-    this.initialTribute,
-    super.key
-  });
+  const TransactionInputModal(
+      {required this.onSave, this.initialTransaction, super.key});
 
   @override
   State<TransactionInputModal> createState() => _TransactionInputModalState();
@@ -46,23 +44,30 @@ class _TransactionInputModalState extends State<TransactionInputModal> {
   final _amountController = TextEditingController();
   DateTime _selectedDate = DateTime.now();
   String? _selectedCategory;
-  final List<String> _expenseCategories = ['食費', '交通費', '趣味・娯楽', '交際費', '日用品', 'その他'];
+  final List<String> _expenseCategories = [
+    '食費',
+    '交通費',
+    '趣味・娯楽',
+    '交際費',
+    '日用品',
+    'その他'
+  ];
   final List<String> _incomeCategories = ['給与', '副業', '臨時収入', 'その他'];
 
   @override
   void initState() {
     super.initState();
-    if (widget.initialTribute != null) {
-      final tribute = widget.initialTribute!;
-      final amount = tribute['amount'] as int;
-      
+    if (widget.initialTransaction != null) {
+      final transaction = widget.initialTransaction!;
+      final amount = transaction['amount'] as int;
+
       _isExpense = amount < 0;
       _amountController.text = amount.abs().toString();
-      _selectedDate = DateTime.parse(tribute['date']);
-      _selectedCategory = tribute['category'];
+      _selectedDate = DateTime.parse(transaction['date']);
+      _selectedCategory = transaction['category'];
     }
   }
-  
+
   @override
   void dispose() {
     _amountController.dispose();
@@ -77,13 +82,14 @@ class _TransactionInputModalState extends State<TransactionInputModal> {
       );
       return;
     }
-    Map<String, dynamic> tributeData = {
-      'id': widget.initialTribute?['id'] ?? 'tribute_${DateTime.now().millisecondsSinceEpoch}',
+    Map<String, dynamic> transactionData = {
+      'id': widget.initialTransaction?['id'] ??
+          'transaction_${DateTime.now().millisecondsSinceEpoch}',
       'date': _selectedDate.toIso8601String(),
       'amount': _isExpense ? -amount : amount,
       'category': _selectedCategory!
     };
-    widget.onSave(tributeData);
+    widget.onSave(transactionData);
     Navigator.of(context).pop();
   }
 
@@ -103,111 +109,114 @@ class _TransactionInputModalState extends State<TransactionInputModal> {
 
   @override
   Widget build(BuildContext context) {
-    final currentCategories = _isExpense ? _expenseCategories : _incomeCategories;
+    final currentCategories =
+        _isExpense ? _expenseCategories : _incomeCategories;
     return SingleChildScrollView(
       padding: EdgeInsets.only(
-        bottom: MediaQuery.of(context).viewInsets.bottom,
-        left: 24,
-        right: 24,
-        top: 20
-      ),
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+          left: 24,
+          right: 24,
+          top: 20),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-           Text(
-             widget.initialTribute == null ? '収支の入力' : '履歴の編集',
-             textAlign: TextAlign.center,
-             style: Theme.of(context).textTheme.titleLarge,
-           ),
-           const SizedBox(height: 24),
-           Center(
-             child: ToggleButtons(
-               isSelected: [_isExpense, !_isExpense],
-               onPressed: (index) {
-                 setState(() {
-                   _isExpense = index == 0;
-                   _selectedCategory = null;
-                 });
-               },
-               borderRadius: BorderRadius.circular(8),
-               selectedColor: AppColors.subText,
-               fillColor: _isExpense ? AppColors.primary : AppColors.secondary,
-               children: const [
-                 Padding(
-                   padding: EdgeInsets.symmetric(horizontal: 24),
-                   child: Text('支出'),
-                 ),
-                 Padding(
-                   padding: EdgeInsets.symmetric(horizontal: 24),
-                   child: Text('収入'),
-                 ),
-               ],
-             ),
-           ),
-           const SizedBox(height: 20),
-           TextField(
-             controller: _amountController,
-             keyboardType: TextInputType.number,
-             decoration: const InputDecoration(
-               labelText: '金額',
-               prefixIcon: Icon(Icons.currency_yen),
-               border: OutlineInputBorder(),
-             ),
-           ),
-           const SizedBox(height: 16),
-           DropdownButtonFormField<String>(
-             value: _selectedCategory,
-             hint: const Text('カテゴリを選択'),
-             decoration: const InputDecoration(
-               labelText: 'カテゴリ',
-               prefixIcon: Icon(Icons.category_outlined),
-               border: OutlineInputBorder(),
-             ),
-             items: currentCategories.map((String category) {
-               return DropdownMenuItem<String>(
-                 value: category,
-                 child: Text(category),
-               );
-             }).toList(),
-             onChanged: (String? newValue) {
-               setState(() {
-                 _selectedCategory = newValue;
-               });
-             },
-           ),
-           const SizedBox(height: 24),
-           InkWell(
-             onTap: () => _selectDate(context),
-             child: Padding(
-               padding: const EdgeInsets.symmetric(vertical: 8.0),
-               child: Row(
-                 children: [
-                   const Icon(Icons.calendar_today_outlined, color: AppColors.subIcon),
-                   const SizedBox(width: 12),
-                   Text(
-                     '日付: ${DateFormat('yyyy-MM-dd').format(_selectedDate)}',
-                     style: const TextStyle(fontSize: 16),
-                   ),
-                   const Spacer(),
-                   const Icon(Icons.edit_outlined, color: AppColors.subIcon, size: 20),
-                 ],
-               ),
-             ),
-           ),
-           const Divider(),
-           const SizedBox(height: 10),
-           ElevatedButton(
-             onPressed: _saveTransaction,
-             style: ElevatedButton.styleFrom(
-               backgroundColor: AppColors.primary,
-               foregroundColor: AppColors.mainIcon,
-               padding: const EdgeInsets.symmetric(vertical: 16),
-               textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-             ),
-             child: const Text('保存する'),
-           ),
-           const SizedBox(height: 8),
+          Text(
+            widget.initialTransaction == null ? '収支の入力' : '履歴の編集',
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 24),
+          Center(
+            child: ToggleButtons(
+              isSelected: [_isExpense, !_isExpense],
+              onPressed: (index) {
+                setState(() {
+                  _isExpense = index == 0;
+                  _selectedCategory = null;
+                });
+              },
+              borderRadius: BorderRadius.circular(8),
+              selectedColor: AppColors.subText,
+              fillColor: _isExpense ? AppColors.primary : AppColors.secondary,
+              children: const [
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 24),
+                  child: Text('支出'),
+                ),
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 24),
+                  child: Text('収入'),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 20),
+          TextField(
+            controller: _amountController,
+            keyboardType: TextInputType.number,
+            decoration: const InputDecoration(
+              labelText: '金額',
+              prefixIcon: Icon(Icons.currency_yen),
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 16),
+          DropdownButtonFormField<String>(
+            value: _selectedCategory,
+            hint: const Text('カテゴリを選択'),
+            decoration: const InputDecoration(
+              labelText: 'カテゴリ',
+              prefixIcon: Icon(Icons.category_outlined),
+              border: OutlineInputBorder(),
+            ),
+            items: currentCategories.map((String category) {
+              return DropdownMenuItem<String>(
+                value: category,
+                child: Text(category),
+              );
+            }).toList(),
+            onChanged: (String? newValue) {
+              setState(() {
+                _selectedCategory = newValue;
+              });
+            },
+          ),
+          const SizedBox(height: 24),
+          InkWell(
+            onTap: () => _selectDate(context),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8.0),
+              child: Row(
+                children: [
+                  const Icon(Icons.calendar_today_outlined,
+                      color: AppColors.subIcon),
+                  const SizedBox(width: 12),
+                  Text(
+                    '日付: ${DateFormat('yyyy-MM-dd').format(_selectedDate)}',
+                    style: const TextStyle(fontSize: 16),
+                  ),
+                  const Spacer(),
+                  const Icon(Icons.edit_outlined,
+                      color: AppColors.subIcon, size: 20),
+                ],
+              ),
+            ),
+          ),
+          const Divider(),
+          const SizedBox(height: 10),
+          ElevatedButton(
+            onPressed: _saveTransaction,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppColors.primary,
+              foregroundColor: AppColors.mainIcon,
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              textStyle:
+                  const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+            child: const Text('保存する'),
+          ),
+          const SizedBox(height: 8),
         ],
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -89,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -386,6 +402,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   stack_trace:
     dependency: transitive
     description:
@@ -442,6 +466,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  uuid:
+    dependency: "direct main"
+    description:
+      name: uuid
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.1"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   intl: ^0.20.2
   flutter_riverpod: ^2.5.1
   riverpod_annotation: ^2.6.1
+  uuid: ^4.5.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 関連issue
(#45 , #52 )

## 行った変更の説明
以下のデータをprovider経由で取得するようにしました。
・好感度
・支出履歴
・貢ぎ履歴
・設定
・ユニークID
これにより情報源が一か所になり、データの不整合や状態の変化に対応しやすくなります。

また、データの定義をlib\modelsにまとめました。
・エピソード
・設定
・支出履歴とカレンダーの日付
・貢ぎ履歴

また、ローカルストレージでデータを以下の取得、保存するときにlib\repositoriesを経由するようにしました。
・設定
・支出履歴
・貢ぎ履歴

## メンバーに伝えること（もしあれば）
・riverpodを使うメリットは、単体テストがしやすくなることです。しかし、まだテストを一つも書いてません。MVPができた後で良いですが、将来的にこのテストを書く必要があります。
・ローカルストレージに保存するデータですが、uuidをつける方が扱いやすいです。貢ぎ履歴にはuuidの項目をつけてますが、支出履歴にはつけてません。追加する必要があります。
・支出履歴のデータ型を変えたせいで、支出が収入として表示されています(下記画像参照)。これも修正する必要があります。
<img width="393" height="820" alt="image" src="https://github.com/user-attachments/assets/59377555-e715-4b1d-b14f-f9698094fd11" />
