### PR TITLE
bugを修正

### DIFF
--- a/lib/providers/transaction_history_provider.dart
+++ b/lib/providers/transaction_history_provider.dart
@@ -41,8 +41,8 @@ class TransactionHistoryNotifier
     );
   }
 
-  void changeMonth(int direction) {
-    final currentState = state.value!;
+  void changeMonth(int direction) async {
+    final currentState = state.value ?? await future;
 
     int newMonth = currentState.currentMonth + direction;
     int newYear = currentState.currentYear;
@@ -61,9 +61,8 @@ class TransactionHistoryNotifier
     ));
   }
 
-  void selectDate(DateTime date) {
-    final currentState = state.value;
-    if (currentState == null) return;
+  void selectDate(DateTime date) async {
+    final currentState = state.value ?? await future;
 
     // 全履歴の中から、選択された日付と一致するものだけをフィルタリング
     final filteredTransactions =
@@ -82,8 +81,8 @@ class TransactionHistoryNotifier
   }
 
   Future<void> addTransaction(Map<String, dynamic> newTransaction) async {
-    final currentState = state.value;
-    if (currentState == null) return;
+    // state.valueがnullの場合、futureを使って状態を初期化する
+    final currentState = state.value ?? await future;
 
     final currentHistory =
         List<Map<String, dynamic>>.from(currentState.transactionHistory);
@@ -108,8 +107,7 @@ class TransactionHistoryNotifier
 
   Future<void> updateTransaction(
       String id, Map<String, dynamic> updatedTransaction) async {
-    final currentState = state.value;
-    if (currentState == null) return;
+    final currentState = state.value ?? await future;
     final currentHistory =
         List<Map<String, dynamic>>.from(currentState.transactionHistory);
     final index =

--- a/lib/providers/tribute_history_provider.dart
+++ b/lib/providers/tribute_history_provider.dart
@@ -61,7 +61,6 @@ class TributeHistoryNotifier
     } catch (e) {
       state = AsyncValue.data(currentState);
       print('Failed to save tribute: $e');
-      //
     }
   }
 }

--- a/lib/screen/transaction_history_screen.dart
+++ b/lib/screen/transaction_history_screen.dart
@@ -24,7 +24,6 @@ class TransactionHistoryScreen extends ConsumerWidget {
       } else {
         formatted = '$amount円';
       }
-      // ここを修正する
       return amount < 0 ? '-$formatted' : formatted;
     }
 

--- a/lib/screen/transaction_history_screen.dart
+++ b/lib/screen/transaction_history_screen.dart
@@ -14,18 +14,17 @@ class TransactionHistoryScreen extends ConsumerWidget {
     final selectedTransactions = ref.watch(selectedTransactionsProvider);
 
     // --- 金額フォーマット関数 ---
-    String formatAmount(int amount) {
-      final absAmount = amount.abs();
+    String formatAmount(final int amount) {
       String formatted;
 
-      if (absAmount >= 1000000) {
-        formatted = '${(absAmount / 1000000).toStringAsFixed(1)}m';
-      } else if (absAmount >= 10000) {
-        formatted = '${(absAmount / 1000).toStringAsFixed(1)}k';
+      if (amount >= 1000000) {
+        formatted = '${(amount / 1000000).toStringAsFixed(1)}m';
+      } else if (amount >= 10000) {
+        formatted = '${(amount / 1000).toStringAsFixed(1)}k';
       } else {
-        formatted = '$absAmount円';
+        formatted = '$amount円';
       }
-
+      // ここを修正する
       return amount < 0 ? '-$formatted' : formatted;
     }
 
@@ -37,17 +36,17 @@ class TransactionHistoryScreen extends ConsumerWidget {
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (err, stack) => Center(child: Text('エラー: $err')),
         data: (state) {
-          // --- 日別の合計献金金額を計算 ---
           Map<String, int> calculateDailyTransactions() {
             final dailyTransaction = <String, int>{};
             for (var transaction in state.transactionHistory) {
               final date = DateTime.parse(transaction['date']);
+              final amount = transaction['amount'] as int;
               if (date.month == state.currentMonth &&
                   date.year == state.currentYear) {
                 final formattedDate = DateFormat('yyyy-MM-dd').format(date);
                 dailyTransaction[formattedDate] =
                     (dailyTransaction[formattedDate] ?? 0) +
-                        (transaction['amount'] as int);
+                        (transaction['type'] == "income" ? amount : -amount);
               }
             }
             return dailyTransaction;
@@ -217,6 +216,7 @@ class TransactionHistoryScreen extends ConsumerWidget {
                         itemCount: selectedTransactions.length,
                         itemBuilder: (context, index) {
                           final transaction = selectedTransactions[index];
+                          final type = transaction['type'] as String;
                           final amount = transaction['amount'] as int;
                           final category =
                               transaction['category'] as String? ?? 'カテゴリなし';
@@ -225,10 +225,12 @@ class TransactionHistoryScreen extends ConsumerWidget {
                             margin: const EdgeInsets.symmetric(vertical: 4),
                             child: ListTile(
                               leading: Icon(
-                                amount >= 0
+                                type == "income"
                                     ? Icons.arrow_upward
                                     : Icons.arrow_downward,
-                                color: amount >= 0 ? Colors.green : Colors.red,
+                                color: type == "income"
+                                    ? Colors.green
+                                    : Colors.red,
                               ),
                               title: Text(category),
                               trailing: Row(
@@ -237,7 +239,7 @@ class TransactionHistoryScreen extends ConsumerWidget {
                                   Text(
                                     formatAmount(amount), // k/m表記に変換
                                     style: TextStyle(
-                                      color: amount >= 0
+                                      color: type == "income"
                                           ? Colors.green
                                           : Colors.red,
                                       fontWeight: FontWeight.bold,
@@ -251,13 +253,13 @@ class TransactionHistoryScreen extends ConsumerWidget {
                                       showTransactionModal(
                                         context,
                                         onSave: (updatedData) {
-                                          final TransactionId =
+                                          final transactionId =
                                               updatedData['id'] as String;
                                           ref
                                               .read(transactionHistoryProvider
                                                   .notifier)
                                               .updateTransaction(
-                                                  TransactionId, updatedData);
+                                                  transactionId, updatedData);
                                         },
                                         initialTransaction: transaction,
                                       );

--- a/lib/services/local_storage_service.dart
+++ b/lib/services/local_storage_service.dart
@@ -119,9 +119,9 @@ class LocalStorageService {
 // characterA_likeability: 85(int)
 // transaction_history
 // [
-//   {"type": "income", "date": "2024-06-25", "amount": 50000, "category": category},
-//   {"type": "expense", "date": "2024-06-25", "amount": 1000, "category": category},
-//   {"type": "expense", "date": "2024-06-26", "amount": 500, "category": category},
+//   {"id": "transaction_1759380715075", "type": "income", "date": "2024-06-25", "amount": 50000, "category": category},
+//   {"id": "transaction_1759380715075", "type": "expense", "date": "2024-06-25", "amount": 1000, "category": category},
+//   {"id": "transaction_1759380715075", "type": "expense", "date": "2024-06-26", "amount": 500, "category": category},
 // ]List<String>
 // tribute_history
 // [


### PR DESCRIPTION
## 関連issue
(#58)

## 行った変更の説明
以下のバグを修正しました。
・支出履歴画面を開かずに、支出を入力すると、支出が保存されない
・支出が収入として表示される

### 前者：
TransactionHistoryNotifierのstateがnullであることが原因。
### 後者：
支出を負の数、収入を正の数で保存していた。これをtype: "income"とtype: "expense"で判別し、値は必ず正の数になるように変更したことが原因。
それぞれ修正しました。

## 画面のデザインを示すスクショ（もしあれば）
正しく動作しています。
<img width="393" height="614" alt="image" src="https://github.com/user-attachments/assets/d25a9afd-6154-4029-ac63-f567d76d3c6b" />

## メンバーに伝えること（もしあれば）
lib\screen\transaction_history_screen.dartで複数の個所でtype == "income"という条件式が出てきます。この処理を一つの関数として共通化すべきですが、していません。将来的に対応すべきです。
