### PR TITLE
Issue/49

### DIFF
--- a/lib/constants/settings_defaults.dart
+++ b/lib/constants/settings_defaults.dart
@@ -1,0 +1,7 @@
+class SettingsDefaults {
+  // 静的（static）かつ定数（const）として定義
+  static const int targetSavingAmount = 100000;
+  static const int dailyBudget = 500;
+  static const bool notificationsEnabled = true;
+  static const double bgmVolume = 70;
+}

--- a/lib/models/settings_state.dart
+++ b/lib/models/settings_state.dart
@@ -1,27 +1,27 @@
 class SettingsState {
-  final int targetSavingAmount;
-  final int defaultContributionAmount;
   final bool notificationsEnabled;
   final double bgmVolume;
+  final int targetSavingAmount;
+  final int dailyBudget;
 
-  SettingsState(
-      {required this.targetSavingAmount,
-      required this.defaultContributionAmount,
-      required this.notificationsEnabled,
-      required this.bgmVolume});
+  SettingsState({
+    required this.notificationsEnabled,
+    required this.bgmVolume,
+    required this.targetSavingAmount,
+    required this.dailyBudget,
+  });
 
   SettingsState copyWith({
-    int? targetSavingAmount,
-    int? defaultContributionAmount,
     bool? notificationsEnabled,
     double? bgmVolume,
+    int? targetSavingAmount,
+    int? dailyBudget,
   }) {
     return SettingsState(
-      targetSavingAmount: targetSavingAmount ?? this.targetSavingAmount,
-      defaultContributionAmount:
-          defaultContributionAmount ?? this.defaultContributionAmount,
       notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
       bgmVolume: bgmVolume ?? this.bgmVolume,
+      targetSavingAmount: targetSavingAmount ?? this.targetSavingAmount,
+      dailyBudget: dailyBudget ?? this.dailyBudget,
     );
   }
 }

--- a/lib/providers/likeability_provider.dart
+++ b/lib/providers/likeability_provider.dart
@@ -25,18 +25,16 @@ final likeabilityProvider = Provider<AsyncValue<double>>((ref) {
 
   final int totalTribute = history.fold(0, (sum, item) => sum + item.amount);
   final int targetAmount = settings.targetSavingAmount;
-  final int initialAmount = settings.defaultContributionAmount;
 
   // 計算式に基づいて好感度を算出する
-  final int goalToSave = targetAmount - initialAmount;
 
   // もう達成している場合は、達成率を100%として扱う
-  if (goalToSave <= 0) {
+  if (targetAmount <= 0) {
     return const AsyncValue.data(100.0);
   }
 
   // 達成率を計算
-  final double progressRatio = totalTribute / goalToSave;
+  final double progressRatio = totalTribute / targetAmount;
 
   // 達成率がマイナスにならないように0で下限を設定
   final double clampedRatio = max(0.0, progressRatio);

--- a/lib/providers/setting_provider.dart
+++ b/lib/providers/setting_provider.dart
@@ -11,7 +11,20 @@ class SettingNotifier extends AsyncNotifier<SettingsState> {
     final settingsRepository = await _settingsRepositoryFuture;
     return settingsRepository.getSettings();
   }
+
+  Future<void> saveSettings(SettingsState newSettings) async {
+    final settingsRepository = await _settingsRepositoryFuture;
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() async {
+      await settingsRepository.saveSettings(newSettings);
+      return newSettings;
+    });
+  }
 }
+
+final settingsProvider = AsyncNotifierProvider<SettingNotifier, SettingsState>(
+  SettingNotifier.new,
+);
 
 final settingsRepositoryProvider =
     FutureProvider<SettingsRepository>((ref) async {
@@ -19,7 +32,3 @@ final settingsRepositoryProvider =
       await ref.watch(localStorageServiceProvider.future);
   return SettingsRepository(localStorageService);
 });
-
-final settingsProvider = AsyncNotifierProvider<SettingNotifier, SettingsState>(
-  SettingNotifier.new,
-);

--- a/lib/providers/setting_provider.dart
+++ b/lib/providers/setting_provider.dart
@@ -12,13 +12,35 @@ class SettingNotifier extends AsyncNotifier<SettingsState> {
     return settingsRepository.getSettings();
   }
 
-  Future<void> saveSettings(SettingsState newSettings) async {
+  Future<void> _saveSettings(SettingsState newSettings) async {
     final settingsRepository = await _settingsRepositoryFuture;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       await settingsRepository.saveSettings(newSettings);
       return newSettings;
     });
+  }
+
+  Future<void> updateNotification(final bool isEnabled) async {
+    final currentState = state.value ?? await future;
+    final newSettings = currentState.copyWith(notificationsEnabled: isEnabled);
+    await _saveSettings(newSettings);
+  }
+
+  Future<void> updateBgmVolume(final double volume) async {
+    final currentState = state.value ?? await future;
+    final newSettings = currentState.copyWith(bgmVolume: volume);
+    await _saveSettings(newSettings);
+  }
+
+  Future<void> updateSavingGoals({
+    required int targetSavingAmount,
+    required int dailyBudget,
+  }) async {
+    final currentState = state.value ?? await future;
+    final newSettings = currentState.copyWith(
+        targetSavingAmount: targetSavingAmount, dailyBudget: dailyBudget);
+    await _saveSettings(newSettings);
   }
 }
 

--- a/lib/screen/settings_screen.dart
+++ b/lib/screen/settings_screen.dart
@@ -1,15 +1,50 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
+import 'package:saving_girlfriend/constants/color.dart';
+import 'package:saving_girlfriend/constants/settings_defaults.dart';
+import 'package:saving_girlfriend/models/settings_state.dart';
+import '../providers/setting_provider.dart';
+import 'package:go_router/go_router.dart';
 
-class SettingsScreen extends StatefulWidget {
-  const SettingsScreen({Key? key}) : super(key: key);
+class SettingsScreen extends ConsumerStatefulWidget {
+  const SettingsScreen({super.key});
 
   @override
-  State<SettingsScreen> createState() => _SettingsScreenState();
+  ConsumerState<SettingsScreen> createState() => _SettingsScreenState();
 }
 
-class _SettingsScreenState extends State<SettingsScreen> {
-  bool isNotificationOn = true;
-  double bgmVolume = 30; // 初期値30%
+class _SettingsScreenState extends ConsumerState<SettingsScreen> {
+  late bool notificationsEnabled;
+  late double bgmVolume;
+  final TextEditingController targetSavingsController = TextEditingController();
+  final TextEditingController dailyBudgetController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    final initialSettings = ref.read(settingsProvider).value;
+    if (initialSettings != null) {
+      notificationsEnabled = initialSettings.notificationsEnabled;
+      bgmVolume = initialSettings.bgmVolume;
+      targetSavingsController.text =
+          (initialSettings.targetSavingAmount / 10000).toInt().toString();
+      dailyBudgetController.text = initialSettings.dailyBudget.toString();
+    } else {
+      notificationsEnabled = SettingsDefaults.notificationsEnabled;
+      bgmVolume = SettingsDefaults.bgmVolume;
+      targetSavingsController.text =
+          (SettingsDefaults.targetSavingAmount / 10000).toInt().toString();
+      dailyBudgetController.text = SettingsDefaults.dailyBudget.toString();
+    }
+  }
+
+  @override
+  void dispose() {
+    targetSavingsController.dispose();
+    dailyBudgetController.dispose();
+    super.dispose();
+  }
 
   // 音量に応じたアイコンを返す
   IconData getVolumeIcon() {
@@ -22,82 +57,312 @@ class _SettingsScreenState extends State<SettingsScreen> {
     }
   }
 
+  // 設定を保存する処理
+  void saveSettings() async {
+    final newSettings = SettingsState(
+      notificationsEnabled: notificationsEnabled,
+      bgmVolume: bgmVolume,
+      targetSavingAmount: (int.tryParse(targetSavingsController.text) ??
+              (SettingsDefaults.targetSavingAmount / 10000).toInt()) *
+          10000,
+      dailyBudget: int.tryParse(dailyBudgetController.text) ??
+          SettingsDefaults.dailyBudget,
+    );
+    await ref.read(settingsProvider.notifier).saveSettings(newSettings);
+
+    if (mounted) {
+      context.pop();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('設定'),
-        backgroundColor: Colors.pink[100],
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // 通知設定
-            const Text(
-              '通知',
-              style: TextStyle(fontSize: 18),
+    final settingAsyncValue = ref.watch(settingsProvider);
+    return settingAsyncValue.when(
+        loading: () => const Scaffold(
+              backgroundColor: AppColors.forthBackground,
+              body: Center(child: CircularProgressIndicator()),
             ),
-            const SizedBox(height: 10),
-            ToggleButtons(
-              isSelected: [!isNotificationOn, isNotificationOn],
-              onPressed: (index) {
-                setState(() {
-                  isNotificationOn = (index == 1);
-                });
-              },
-              selectedColor: Colors.white,
-              fillColor: Colors.pink[200],
-              color: Colors.pink[200],
-              borderRadius: BorderRadius.circular(10),
-              children: const [
-                Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 20),
-                  child: Text('OFF'),
-                ),
-                Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 20),
-                  child: Text('ON'),
-                ),
-              ],
+        error: (error, stackTrace) => Scaffold(
+              backgroundColor: AppColors.forthBackground,
+              body: Center(child: Text('エラーが発生しました: $error')),
             ),
+        data: (settings) {
+          return Scaffold(
+            backgroundColor: AppColors.forthBackground,
+            appBar: AppBar(
+              title: const Text('設定'),
+              backgroundColor: AppColors.secondary,
+            ),
+            body: SingleChildScrollView(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 24, 16, 24),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // --- アプリセクション ---
+                    _buildSectionHeader('アプリ', Icons.tune),
+                    _buildSettingsContainer(
+                      children: [
+                        // --- 通知 ---
+                        Row(
+                          children: [
+                            const Expanded(
+                              child: Text(
+                                '通知',
+                                style: TextStyle(fontSize: 18),
+                              ),
+                            ),
+                            SizedBox(
+                              width: 220,
+                              child: Align(
+                                alignment: Alignment.centerRight,
+                                child: ToggleButtons(
+                                  isSelected: [
+                                    !notificationsEnabled,
+                                    notificationsEnabled
+                                  ],
+                                  onPressed: (index) {
+                                    setState(() {
+                                      notificationsEnabled = (index == 1);
+                                    });
+                                  },
+                                  selectedColor: AppColors.mainBackground,
+                                  fillColor: AppColors.primary,
+                                  color: AppColors.secondary,
+                                  borderRadius: BorderRadius.circular(10),
+                                  children: const [
+                                    Padding(
+                                      padding:
+                                          EdgeInsets.symmetric(horizontal: 20),
+                                      child: Text('OFF'),
+                                    ),
+                                    Padding(
+                                      padding:
+                                          EdgeInsets.symmetric(horizontal: 20),
+                                      child: Text('ON'),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const Divider(),
+                        // --- BGM音量設定 ---
+                        Row(
+                          children: [
+                            const Expanded(
+                              child: Text(
+                                'BGM',
+                                style: TextStyle(fontSize: 18),
+                              ),
+                            ),
+                            SizedBox(
+                              width: 220,
+                              child: Row(
+                                children: [
+                                  Icon(
+                                    getVolumeIcon(),
+                                    size: 28,
+                                    color: AppColors.secondary,
+                                  ),
+                                  Expanded(
+                                    child: Slider(
+                                      value: bgmVolume,
+                                      min: 0,
+                                      max: 100,
+                                      divisions: 50,
+                                      activeColor: AppColors.secondary,
+                                      onChanged: (value) {
+                                        setState(() {
+                                          bgmVolume = value;
+                                        });
+                                      },
+                                    ),
+                                  ),
+                                  SizedBox(
+                                    width: 40,
+                                    child: Text(
+                                      '${bgmVolume.toInt()}%',
+                                      textAlign: TextAlign.center,
+                                      style: const TextStyle(
+                                        fontSize: 14,
+                                        color: AppColors.primary,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
 
-            const SizedBox(height: 40),
+                    const SizedBox(height: 20),
 
-            // BGM音量設定
-            Row(
-              children: [
-                const Text(
-                  'BGM',
-                  style: TextStyle(fontSize: 18),
+                    // --- 貯金セクション ---
+                    _buildSectionHeader('貯金', Icons.savings),
+                    _buildSettingsContainer(
+                      children: [
+                        // --- 目標 ---
+                        Row(
+                          children: [
+                            const Expanded(
+                              // ✅ レイアウトを統一
+                              child: Text(
+                                '目標',
+                                style: TextStyle(fontSize: 18),
+                              ),
+                            ),
+                            SizedBox(
+                              // ✅ レイアウトを統一
+                              width: 220,
+                              child: Align(
+                                alignment: Alignment.centerRight,
+                                child: SizedBox(
+                                  width: 130, // TextField自体の幅はここで調整
+                                  child: TextField(
+                                    controller: targetSavingsController,
+                                    keyboardType: TextInputType.number,
+                                    textAlign: TextAlign.right, // 右寄せにする
+                                    decoration: InputDecoration(
+                                      border: OutlineInputBorder(
+                                        borderRadius: BorderRadius.circular(10),
+                                      ),
+                                      focusedBorder: OutlineInputBorder(
+                                        borderRadius: BorderRadius.circular(10),
+                                        borderSide: const BorderSide(
+                                            color: AppColors.secondary),
+                                      ),
+                                      suffixText: '万円',
+                                      contentPadding:
+                                          const EdgeInsets.symmetric(
+                                              horizontal: 16, vertical: 12),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const Divider(),
+                        // --- 一日に使える金額 ---
+                        Row(
+                          children: [
+                            const Expanded(
+                              // ✅ レイアウトを統一
+                              child: Text(
+                                '一日に使える金額',
+                                style: TextStyle(fontSize: 18),
+                              ),
+                            ),
+                            SizedBox(
+                              // ✅ レイアウトを統一
+                              width: 220,
+                              child: Align(
+                                alignment: Alignment.centerRight,
+                                child: SizedBox(
+                                  width: 130, // TextField自体の幅はここで調整
+                                  child: TextField(
+                                    controller: dailyBudgetController,
+                                    keyboardType: TextInputType.number,
+                                    textAlign: TextAlign.right,
+                                    decoration: InputDecoration(
+                                      border: OutlineInputBorder(
+                                        borderRadius: BorderRadius.circular(10),
+                                      ),
+                                      focusedBorder: OutlineInputBorder(
+                                        borderRadius: BorderRadius.circular(10),
+                                        borderSide: const BorderSide(
+                                            color: AppColors.secondary),
+                                      ),
+                                      suffixText: '円',
+                                      contentPadding:
+                                          const EdgeInsets.symmetric(
+                                              horizontal: 16, vertical: 12),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+
+                    // ( OKボタンなどはこの下に続く... )
+                    const SizedBox(height: 40),
+                    // OKボタン
+                    Center(
+                      child: SizedBox(
+                        width: double.infinity,
+                        height: 50,
+                        child: ElevatedButton(
+                          onPressed: saveSettings,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: AppColors.primary,
+                            foregroundColor: AppColors.subText,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(10),
+                            ),
+                          ),
+                          child: const Text(
+                            'OK',
+                            style: TextStyle(fontSize: 18),
+                          ),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+                  ],
                 ),
-                const SizedBox(width: 20),
-                Icon(
-                  getVolumeIcon(),
-                  size: 28,
-                  color: Colors.pink[200],
-                ),
-                Expanded(
-                  child: Slider(
-                    value: bgmVolume,
-                    min: 0,
-                    max: 100,
-                    divisions: 100,
-                    activeColor: Colors.pink[200],
-                    onChanged: (value) {
-                      setState(() {
-                        bgmVolume = value;
-                      });
-                    },
-                  ),
-                ),
-                // 右の音量アイコンは削除済み
-              ],
+              ),
             ),
-          ],
-        ),
-      ),
-    );
+          );
+        });
   }
+}
+
+Widget _buildSectionHeader(String title, IconData icon) {
+  return Padding(
+    padding: const EdgeInsets.only(bottom: 16.0), // 下のpaddingを調整
+    child: Row(
+      children: [
+        Icon(icon, color: AppColors.secondary, size: 22),
+        const SizedBox(width: 8),
+        Text(
+          title,
+          style: const TextStyle(
+            fontSize: 18, // 少し大きく
+            fontWeight: FontWeight.bold,
+            color: AppColors.primary,
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+Widget _buildSettingsContainer({required List<Widget> children}) {
+  return Container(
+    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+    decoration: BoxDecoration(
+      color: AppColors.mainBackground, // 背景色を白に
+      borderRadius: BorderRadius.circular(12),
+      boxShadow: [
+        // ほんのり影をつけて立体感を出す
+        BoxShadow(
+          color: Colors.grey.withOpacity(0.2),
+          spreadRadius: 1,
+          blurRadius: 5,
+          offset: const Offset(0, 3),
+        ),
+      ],
+    ),
+    child: Column(
+      children: children,
+    ),
+  );
 }

--- a/lib/services/local_storage_service.dart
+++ b/lib/services/local_storage_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:saving_girlfriend/constants/settings_defaults.dart';
 import 'package:saving_girlfriend/models/settings_state.dart';
 import 'package:saving_girlfriend/models/tribute_history_state.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -24,11 +25,11 @@ class LocalStorageService {
   static const String _likeabilityKeyPrefix = '_likeability'; // キャラごとに好感度を保存
   static const String _transactionHistoryKey = 'transaction_history';
   static const String _tributionHistoryKey = 'tribution_history';
-  static const String _targetSavingAmountKey = 'target_saving_amount';
-  static const String _defaultContributionAmountKey =
-      'default_contribution_amount';
+  // 設定関連のキー
   static const String _notificationsEnabledKey = 'notifications_enabled';
   static const String _bgmVolumeKey = 'bgm_volume';
+  static const String _targetSavingAmountKey = 'target_saving_amount';
+  static const String _dailyBudgetAmountKey = 'daily_budget_amount';
 
   // --- 保存 (Save) ---
 
@@ -49,8 +50,7 @@ class LocalStorageService {
 
   Future<void> saveSettings(SettingsState setting) async {
     await _prefs.setInt(_targetSavingAmountKey, setting.targetSavingAmount);
-    await _prefs.setInt(
-        _defaultContributionAmountKey, setting.defaultContributionAmount);
+    await _prefs.setInt(_dailyBudgetAmountKey, setting.dailyBudget);
     await _prefs.setBool(
         _notificationsEnabledKey, setting.notificationsEnabled);
     await _prefs.setDouble(_bgmVolumeKey, setting.bgmVolume);
@@ -99,16 +99,19 @@ class LocalStorageService {
   }
 
   Future<SettingsState> getSettings() async {
-    final int targetSavingAmount =
-        _prefs.getInt(_targetSavingAmountKey) ?? 100000;
-    final int defaultContributionAmount =
-        _prefs.getInt(_defaultContributionAmountKey) ?? 500;
     final bool notificationsEnabled =
-        _prefs.getBool(_notificationsEnabledKey) ?? true;
-    final double bgmVolume = _prefs.getDouble(_bgmVolumeKey) ?? 0.75;
+        _prefs.getBool(_notificationsEnabledKey) ??
+            SettingsDefaults.notificationsEnabled;
+    final double bgmVolume =
+        _prefs.getDouble(_bgmVolumeKey) ?? SettingsDefaults.bgmVolume;
+    final int targetSavingAmount = _prefs.getInt(_targetSavingAmountKey) ??
+        SettingsDefaults.targetSavingAmount;
+    final int dailyBudget =
+        _prefs.getInt(_dailyBudgetAmountKey) ?? SettingsDefaults.dailyBudget;
+
     return SettingsState(
         targetSavingAmount: targetSavingAmount,
-        defaultContributionAmount: defaultContributionAmount,
+        dailyBudget: dailyBudget,
         notificationsEnabled: notificationsEnabled,
         bgmVolume: bgmVolume);
   }
@@ -130,9 +133,8 @@ class LocalStorageService {
 //  {"id": 0101101001..., "character": "SuzunariOto", "date": "2024-06-25", "amount": 500},
 // ]
 
-// target_saving_amount: 100000 (int)
-// default_contribution_amount: 500 (int)
-// added_saging_amount: 20000 (int)
-
+// 設定関連
 // notifications_enabled: true (bool)
-// bgm_volume: 0.75 (double)
+// bgm_volume: 75 (double)
+// target_saving_amount: 100000 (int)
+// daily_budget_amount: 1000 (int)

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "lint-staged": {
     "*.dart": [
       "echo Running dart format on:",
-      "dart format",
-      "dart fix --apply"
+      "dart format"
     ]
   }
 }


### PR DESCRIPTION
## 関連issue
(#49 )

## 行った変更の説明
・設定画面を作成した

・設定をローカルストレージに保存するようにした
通知とBGMは値をすぐに保存するようにしています。
目標貯金額と1日に使える金額は「OK」ボタンを押したときに保存するようにしています。
保存せずに前の画面に戻ろうとしたら警告画面を表示するようにしました。

## 画面のデザインを示すスクショ（もしあれば）
設定画面
<img width="427" height="831" alt="image" src="https://github.com/user-attachments/assets/bff01682-3883-461c-9e43-bc3834b28ae9" />

警告画面
<img width="465" height="327" alt="image" src="https://github.com/user-attachments/assets/5d196bbc-dcbf-4d16-bc2f-e205134954f6" />


## メンバーに伝えること（もしあれば）
設定画面のデザインをもう少し拘りたいです。アプリへの没入感を維持するために、システムっぽくないデザインに改善していく必要があります。
